### PR TITLE
[x] - The form action should redirect to the routes/login parameter

### DIFF
--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -17,7 +17,7 @@
     </div>
     {% endif %}
 
-    <form action="{{ page.slug }}" method="post" id="private">
+    <form action="{{ private.routes.login }}" method="post" id="private">
         <fieldset>
 
             <!-- Username input-->


### PR DESCRIPTION
As explained in the README, about routing:

> Routes of login, logout and home page. You can customize it by simple replacement of the value (e.g: login: "/admin" for "mywebsite.com/admin" ) The home option is only for full private website (Bug fix #1)

So the form action should redirect to the given login value in the config file.
